### PR TITLE
Import GTK in a backward compatible way

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,9 @@ There has been [one report](https://github.com/city41/mate-i3-applet/issues/11#i
 
 ## Only supporting GTK3
 
-MATE 1.18.0 made the switch to GTK 3, and so this applet now assumes GTK 3. To go back to GTK 2, edit matei3applet.py, change
-
-`gi.require_version("Gtk", "3.0")`
-
-to
-
-`gi.require_version("Gtk", "2.0")`
-
-but please note I will not address GTK 2 specific issues. Please upgrade to a newer version of MATE instead.
+MATE 1.18.0 made the switch to GTK. This applet checks MATE version and imports appropriate version of GTK,
+however if you use GTK2 and encounter an issue, please upgrade before creating an issue. GTK2 specific issues
+will not be addressed.
 
 ## How to Install
 

--- a/mate_version.py
+++ b/mate_version.py
@@ -1,0 +1,44 @@
+import re
+import subprocess
+import sys
+from collections import namedtuple
+
+MateVersion = namedtuple("MateVersion", ["major", "minor", "patch"])
+pattern = re.compile(
+    b"(?P<major>\d+)\."
+    b"(?P<minor>\d+)\."
+    b"(?P<patch>\d+)"
+)
+
+
+def get_mate_version():
+    """
+    Return namedtuple with major, minor and patch version of Mate
+    or None if Mate is not installed.
+    """
+
+    try:
+        mate_about_output = subprocess.check_output(
+            ("mate-about", "--version")
+        )
+    except FileNotFoundError:
+        return None
+    match = pattern.search(mate_about_output)
+    return (MateVersion(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+    ))
+
+
+def import_gtk():
+    import gi
+
+    version = get_mate_version()
+    if version and version.major <= 2 and version.minor < 18:
+        gi.require_version("Gtk", "2.0")
+    elif version:
+        gi.require_version("Gtk", "3.0")
+    else:
+        # TODO: add logging
+        sys.exit(1)

--- a/mate_version.py
+++ b/mate_version.py
@@ -35,10 +35,12 @@ def import_gtk():
     import gi
 
     version = get_mate_version()
-    if version and version.major <= 2 and version.minor < 18:
+    if version and version.major < 2 and version.minor < 18:
         gi.require_version("Gtk", "2.0")
     elif version:
         gi.require_version("Gtk", "3.0")
     else:
         # TODO: add logging
         sys.exit(1)
+    gi.require_version('MatePanelApplet', '4.0')
+

--- a/matei3applet.py
+++ b/matei3applet.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
- 
-import gi
-gi.require_version("Gtk", "3.0")
-gi.require_version("MatePanelApplet", "4.0")
+
+from mate_version import import_gtk
+import_gtk()
+
 from gi.repository import Gtk
 from gi.repository import GLib
 from gi.repository import MatePanelApplet

--- a/setup.py
+++ b/setup.py
@@ -6,32 +6,35 @@
 #* see README for more information
 
 
-"""applet showing i3 workspaces in MATE""";
-
-
-from distutils.core import setup;
-from distutils.command.install_data import install_data;
+from distutils.core import setup
+from distutils.command.install_data import install_data
 
 
 class InstallData(install_data):
-	def run(self):
-		install_data.run(self);
+    def run(self):
+        install_data.run(self)
 
 
 setup(
-	name = "mate-i3-applet",
-	version = "1.0.0",
-	maintainer = "Matt Greer",
-	maintainer_email = "matt.e.greer@gmail.com",
-	description = "MATE I3 Workspace applet",
-	license = "BSD",
-	scripts = [],
-	url = "https://github.com/city41/mate-i3-applet",
-	package_dir = {},
-	packages = [],
-	data_files=[('/usr/lib/mate-i3-applet', ['matei3applet.py', 'log.py', 'i3conn.py', 'i3ipc.py']),
-		('/usr/share/dbus-1/services', ['matei3applet.service']),
-		('/usr/share/mate-panel/applets', ['matei3applet.mate-panel-applet']),
-	],
-	cmdclass={'install_data': InstallData}
+    name="mate-i3-applet",
+    version="2.0.1",
+    description="MATE i3 Workspace Applet",
+    long_description="Applet for MATE Panel showing i3 workspaces and mode.",
+    license="BSD",
+    url="https://github.com/city41/mate-i3-applet",
+    author="Matt Greer",
+    author_email="matt.e.greer@gmail.com",
+
+    data_files=[
+        ('/usr/lib/mate-i3-applet', [
+            'matei3applet.py',
+            'log.py',
+            'i3conn.py',
+            'i3ipc.py',
+            'mate_version.py',
+        ]),
+        ('/usr/share/dbus-1/services', ['matei3applet.service']),
+        ('/usr/share/mate-panel/applets', ['matei3applet.mate-panel-applet']),
+    ],
+    cmdclass={'install_data': InstallData}
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class InstallData(install_data):
 
 setup(
     name="mate-i3-applet",
-    version="2.0.1",
+    version="2.1.0",
     description="MATE i3 Workspace Applet",
     long_description="Applet for MATE Panel showing i3 workspaces and mode.",
     license="BSD",


### PR DESCRIPTION
This fixes issue #11 without breaking backward compatibility for older versions of MATE. The program will check MATE version and import appropriate GTK. Why is this important? Ubuntu Mate 16.04 is supported until 2021 and that version still requires older version of GTK. A lot of people are stuck at that version (including me) for example at work.

I took the liberty of fixing `setup.py` a little bit, since I had to add a new file there anyway. It used tabs instead of spaces (which are used in all other files - mixed indentation is not allowed in Python 3), there were unnecessary semicolons. I also changed maintainer to author (it makes more sense in your case) and bumped version to 2.0.1.