### PR TITLE
improve logging

### DIFF
--- a/i3conn.py
+++ b/i3conn.py
@@ -1,8 +1,9 @@
-import i3ipc
+import logging
 import threading
 import time
 
-from log import log
+import i3ipc
+
 
 class WorkspaceSub(threading.Thread):
     def __init__(self, con, callback, modeCallback):
@@ -17,11 +18,11 @@ class WorkspaceSub(threading.Thread):
         self.start()
         
     def run(self):
-        log('run')
+        logging.debug('run')
         self.con.event_socket_setup()
 
         while not self.con.event_socket_poll():
-            log('loop')
+            logging.debug('loop')
             
 class I3Conn(object):
     def __init__(self):
@@ -42,7 +43,7 @@ class I3Conn(object):
             self.con = con
 
     def create_connection(self):
-        log('I3Conn create_connection')
+        logging.debug('I3Conn create_connection')
         con = i3ipc.Connection()
         con.on('ipc_shutdown', self.restart)
         return con
@@ -73,7 +74,7 @@ class I3Conn(object):
     # to anyone reading this, I'm brand new to python, which is why I'm stumbling on this
     #
     def go_to_workspace(self, workspace_name):
-        log('go to workspace: ' + workspace_name)
+        logging.debug('go to workspace: {}'.format(workspace_name))
         throwawayCon = i3ipc.Connection()
         throwawayCon.command('workspace ' + workspace_name)
         throwawayCon.close()
@@ -86,13 +87,13 @@ class I3Conn(object):
         self.sub = WorkspaceSub(self.con, self.callback, self.modeCallback)
 
     def close(self):
-        log('I3Conn close')
+        logging.debug('I3Conn close')
         if self.con:
             self.con.close()
             self.con = None
 
     def restart(self, data=None):
-        log('I3Conn restart')
+        logging.debug('I3Conn restart')
         self.close()
 
         self.try_to_connect()

--- a/log.py
+++ b/log.py
@@ -1,21 +1,30 @@
-import os
+import logging
+import sys
+from logging import handlers
+from pathlib import Path
 
-SHOULD_LOG = False
-have_logged = False
 
-def log(message):
-    global SHOULD_LOG
+def exception_handler(type, value, traceback):
+    logging.exception(
+        "Uncaught exception occurred: {}"
+        .format(value)
+    )
 
-    if SHOULD_LOG:
-        global have_logged
-        mode = 'w'
 
-        if have_logged:
-            mode = 'a'
-
-        have_logged = True
-
-        file = open(os.path.expanduser("~/.matei3applet.log"), mode)
-        file.write(message)
-        file.write('\n')
-        file.close()
+def setup_logging():
+    logger = logging.getLogger("")
+    logger.setLevel(logging.WARNING)
+    file_handler = handlers.TimedRotatingFileHandler(
+        Path().home() / ".mate-i3-applet.log",
+        when="D",
+        backupCount=1,
+        delay=True,
+    )
+    file_handler.setFormatter(
+        logging.Formatter(
+            '[%(levelname)s] %(asctime)s: %(message)s',
+            "%Y-%m-%d %H:%M:%S",
+        )
+    )
+    logger.addHandler(file_handler)
+    sys.excepthook = exception_handler

--- a/mate_version.py
+++ b/mate_version.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import subprocess
 import sys
@@ -22,6 +23,7 @@ def get_mate_version():
             ("mate-about", "--version")
         )
     except FileNotFoundError:
+        logging.error("command mate-about was not found")
         return None
     match = pattern.search(mate_about_output)
     return (MateVersion(
@@ -37,10 +39,12 @@ def import_gtk():
     version = get_mate_version()
     if version and version.major < 2 and version.minor < 18:
         gi.require_version("Gtk", "2.0")
+        logging.debug("GTK 2.0 loaded")
     elif version:
         gi.require_version("Gtk", "3.0")
+        logging.debug("GTK 3.0 loaded")
     else:
-        # TODO: add logging
+        logging.error("MATE is not installed, stopping execution..")
         sys.exit(1)
     gi.require_version('MatePanelApplet', '4.0')
 

--- a/matei3applet.py
+++ b/matei3applet.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+import logging
+
+from log import setup_logging
+setup_logging()
+
 from mate_version import import_gtk
 import_gtk()
 
@@ -8,7 +13,6 @@ from gi.repository import GLib
 from gi.repository import MatePanelApplet
 
 from i3conn import I3Conn
-from log import log
 
 DEFAULT_COLORS = {
     'background': '#000000', 
@@ -38,13 +42,13 @@ DEFAULT_COLORS = {
 
 class i3bar(object):
     def __init__(self, applet):
-        log('initting')
+        logging.debug("initializing mate-i3-applet")
         self.applet = applet
         self.applet.connect("destroy", self.destroy)
         self.i3conn = I3Conn()
 
         self.colors = self.init_colors()
-        log('colors: ' + str(self.colors))
+        logging.debug('colors: {}'.format(str(self.colors)))
 
         self.init_widgets()
         self.set_initial_buttons()
@@ -80,22 +84,22 @@ class i3bar(object):
         return colors or DEFAULT_COLORS
 
     def close_sub(self):
-        log('close_sub')
+        logging.debug('close_sub')
         self.i3conn.close()
 
     def open_sub(self):
-        log('open_sub')
+        logging.debug('open_sub')
         self.i3conn.subscribe(self.on_workspace_event, self.on_mode_event)
 
     def on_workspace_event(self, workspaces):
-        log('on_workspace_event')
+        logging.debug('on_workspace_event')
 
         if workspaces:
             GLib.idle_add(self.set_workspace_buttons, workspaces)
 
     def on_mode_event(self, mode):
-        log('on_mode_event')
-        log(mode.change)
+        logging.debug('on_mode_event')
+        logging.debug(mode.change)
 
         GLib.idle_add(self.set_mode_label_text, mode.change)
 
@@ -114,7 +118,7 @@ class i3bar(object):
             self.i3conn.go_to_workspace(workspace['name'])
 
     def set_workspace_buttons(self, workspaces):
-        log('set_workspace_buttons')
+        logging.debug('set_workspace_buttons')
 
         for child in self.box.get_children():
             self.box.remove(child)
@@ -155,7 +159,7 @@ class i3bar(object):
         self.applet.show_all()
 
 def applet_factory(applet, iid, data):
-    log('iid: ' + iid)
+    logging.debug('iid: {}'.format(iid))
     if iid != "I3Applet":
        return False
  


### PR DESCRIPTION
Improved logging, using standard library instead of manually writing to a file.

Settings can be changed in `log.py` (as before). By default it will log only warnings and errors (including uncaught exceptions) to a file `.mate-i3-applet.log` in current user's home directory. Log file will rotate daily and it will not be created unless necessary.

Here is how the log looks like with level set to `DEBUG`:
```
[DEBUG] 2018-10-29 21:02:15: GTK 3.0 loaded
[DEBUG] 2018-10-29 21:02:15: iid: I3Applet
[DEBUG] 2018-10-29 21:02:15: initializing mate-i3-applet
[DEBUG] 2018-10-29 21:02:15: I3Conn create_connection
[DEBUG] 2018-10-29 21:02:15: colors: {'background': '#000000', 'statusline': '#ffffff', 'separator': '#666666', 'binding_mode_border': '#2f343a', 'binding_mode_bg': '#900000', 'binding_mode_text': '#ffffff', 'active_workspace_border': '#333333', 'active_workspace_bg': '#5f676a', 'active_workspace_text': '#ffffff', 'inactive_workspace_border': '#333333', 'inactive_workspace_bg': '#222222', 'inactive_workspace_text': '#888888', 'urgent_workspace_border': '#2f343a', 'urgent_workspace_bg': '#900000', 'urgent_workspace_text': '#ffffff', 'focused_workspace_border': '#4c7899', 'focused_workspace_bg': '#285577', 'focused_workspace_text': '#ffffff'}
[DEBUG] 2018-10-29 21:02:15: set_workspace_buttons
[DEBUG] 2018-10-29 21:02:15: open_sub
[DEBUG] 2018-10-29 21:02:15: run
```

Especially logging all uncaught exceptions should help with fixing bugs in the future.